### PR TITLE
Prepare for release on Bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bower_components
+test
+tests

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+	"name": "glayers.leaflet",
+	"description": "Generic map layers for Leaflet 1.0.0-rc.1",
+	"keywords": [
+		"leaflet",
+		"plugin",
+		"canvas",
+		"layer"
+	],
+	"homepage": "https://github.com/sumbera/glayers.leaflet",
+	"authors": [
+		"Stanislav Sumbera"
+	],
+	"version": "1.0.0",
+	"license": "MIT",
+	"dependencies": {
+		"leaflet": ">= 1.0.0-rc.1"
+	},
+	"main": [
+		"L.CanvasLayer.js"
+	],
+	"ignore": [
+		"**/.*",
+		"node_modules",
+		"bower_components",
+		"test",
+		"tests"
+	]
+}


### PR DESCRIPTION
To prepare for a release on Bower, added bower.json describing
the project. In the future, if new layers are added, they can
be added to the main list.

This is only for the 1.0.0-rc.1 version of Leaflet, as specified
in the dependencies.

Also added a .gitignore to ignore the bower_components directory
(and also test directories while I'm at it).
