### PR TITLE
Fix compatibility issues with 1.0.0-rc.2

### DIFF
--- a/L.CanvasLayer.js
+++ b/L.CanvasLayer.js
@@ -6,7 +6,7 @@
   
 */
 
-L.CanvasLayer = L.Class.extend({
+L.CanvasLayer = L.Layer.extend({
     // -- initialized is called on prototype 
     initialize: function (options) {
         this._map    = null;
@@ -51,8 +51,6 @@ L.CanvasLayer = L.Class.extend({
 
         return events;
     },
-    //-- Leaflet 1.0-rc compatibility  from L.Layer , extension  to get it worked on lf 1.0 rc, this is not called on <1.0 versions 
-    _layerAdd: function (e) { this.onAdd(e.target); },
     //-------------------------------------------------------------
     onAdd: function (map) {
         this._map = map;
@@ -128,18 +126,13 @@ L.CanvasLayer = L.Class.extend({
 
     //------------------------------------------------------------------------------
     _animateZoom: function (e) {
-        var scale = this._map.getZoomScale(e.zoom),
-            offset = this._map._getCenterOffset(e.center)._multiplyBy(-scale).subtract(this._map._getMapPanePos());
+        var scale = this._map.getZoomScale(e.zoom);
+        var offset = this._map._latLngToNewLayerPoint(this._map.getBounds().getNorthWest(), e.zoom, e.center);
 
-        this._canvas.style[L.DomUtil.TRANSFORM] = (L.Browser.ie3d ? 'translate(' + offset.x + 'px,' + offset.y + 'px)' :
-                                                                 'translate3d(' + offset.x + 'px,' + offset.y + 'px,0)') +
-                                                                 (scale ? ' scale(' + scale + ')' : '');
-
+        L.DomUtil.setTransform(this._canvas, offset, scale);
     }
 });
 
 L.canvasLayer = function () {
     return new L.CanvasLayer();
 };
-
-

--- a/L.CanvasLayerSample.html
+++ b/L.CanvasLayerSample.html
@@ -26,8 +26,8 @@
 </head>
 <body>
     <div id="map"></div>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+    <link rel="stylesheet" href="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.css" />
+    <script src="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.js"></script>
     <script src="L.CanvasLayer.js"></script>
     <script src="http://www.sumbera.com/gist/data.js" charset="utf-8"></script>
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "glayers.leaflet",
-	"description": "Generic map layers for Leaflet 1.0.0-rc.1",
+	"description": "Generic map layers for Leaflet 1.0.0-rc.2",
 	"keywords": [
 		"leaflet",
 		"plugin",
@@ -11,10 +11,10 @@
 	"authors": [
 		"Stanislav Sumbera"
 	],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"license": "MIT",
 	"dependencies": {
-		"leaflet": ">= 1.0.0-rc.1"
+		"leaflet": ">= 1.0.0-rc.2"
 	},
 	"main": [
 		"L.CanvasLayer.js"


### PR DESCRIPTION
The _animateZoom function provided was not suitable for use with
1.0.0. I've updated it to work with the new Leaflet API, but
this is unlikely to work with older versions of Leaflet.

Also changed the source to extend from Layer rather than class
to fix issues related to deleting a layer from the map.
