### PR TITLE
Set position of canvas when using pinch to zoom

### DIFF
--- a/L.CanvasLayer.js
+++ b/L.CanvasLayer.js
@@ -56,7 +56,8 @@ L.CanvasLayer = (L.Layer ? L.Layer : L.Class).extend({
     getEvents: function () {
         var events = {
             resize: this._onLayerDidResize,
-            moveend: this._onLayerDidMove
+            moveend: this._onLayerDidMove,
+            zoom: this._onLayerDidMove
         };
         if (this._map.options.zoomAnimation && L.Browser.any3d) {
             events.zoomanim =  this._animateZoom;


### PR DESCRIPTION
When using your canvas layer, dragging around on mobile devices with one finger seems to work perfectly fine.
However, when using pinch and zoom to zoom/drag around the map, the canvas layer stands still while the map layer in the background is moving around.

The zoom event is continuously fired when pinch and zoom/dragging on mobile devices, and only once when zooming on desktop computers.

Maybe there's a better way to solve this? How is the canvas layer re-positioned when dragging normally? I did not find any event handlers for that in the code.